### PR TITLE
Crop box creation disabled. Closes #23.

### DIFF
--- a/client/src/views/uploadPage.vue
+++ b/client/src/views/uploadPage.vue
@@ -419,6 +419,8 @@ async function uploadCroppedImage() {
           :zoomOnTouch="false"
           :movable="false"
           :viewMode="3"
+          :dragMode="'move'"
+          :toggleDragModeOnDblclick="false"
           :restore="false"
           :responsive="false"
           :aspectRatio="1"


### PR DESCRIPTION
This was a super simple change but confusing to implement. 

This is either because of how one needs to declares components in vue html or the documentation for cropperjs itself is unclear. It does seem like the strings passed to parameters in vue html are later interpreted in js. So the following is true.

The value 'move' has to be passed to the parameter dragmode in the following way:
:dragMode="'move'"

not this
:dragMode="move"